### PR TITLE
Bump `ghostwriter/container` from `5.0.0` to `5.0.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "composer-plugin-api": "^2.6.0",
         "composer-runtime-api": "^2.2.2",
         "composer/composer": "^2.8.6",
-        "ghostwriter/container": "^5.0.0",
+        "ghostwriter/container": "^5.0.1",
         "ghostwriter/event-dispatcher": "^5.0.3",
         "ghostwriter/filesystem": "^0.1.1",
         "ghostwriter/json": "^3.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82f3247895703179e85520eeccb60dce",
+    "content-hash": "0a282d831d6500908ca329d391067320",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -646,23 +646,27 @@
         },
         {
             "name": "ghostwriter/container",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/container.git",
-                "reference": "e92b51b825b9b3883bfab6d1077e050bd8035d78"
+                "reference": "e77a71185922b5a67a0219de6acce2d5be8496f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/container/zipball/e92b51b825b9b3883bfab6d1077e050bd8035d78",
-                "reference": "e92b51b825b9b3883bfab6d1077e050bd8035d78",
+                "url": "https://api.github.com/repos/ghostwriter/container/zipball/e77a71185922b5a67a0219de6acce2d5be8496f2",
+                "reference": "e77a71185922b5a67a0219de6acce2d5be8496f2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4"
+                "php": "^8.4"
+            },
+            "provide": {
+                "psr/container-implementation": "*"
             },
             "require-dev": {
-                "ghostwriter/coding-standard": "dev-main"
+                "ghostwriter/coding-standard": "dev-main",
+                "psr/container": "^1.1 || ^2.0"
             },
             "type": "library",
             "autoload": {
@@ -672,7 +676,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "BSD-4-Clause"
             ],
             "authors": [
                 {
@@ -700,7 +704,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-21T19:09:09+00:00"
+            "time": "2025-03-18T19:43:29+00:00"
         },
         {
             "name": "ghostwriter/event-dispatcher",


### PR DESCRIPTION
Bumps `ghostwriter/container` from `5.0.0` to `5.0.1`.

- Update `composer.json`
- Update `composer.lock`