### PR TITLE
Bump `phpunit/phpunit` from `12.2.5` to `12.2.6`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "ghostwriter/coding-standard": "dev-main",
         "infection/infection": "~0.30.1",
         "mockery/mockery": "~1.6.12",
-        "phpunit/phpunit": "~12.2.5",
+        "phpunit/phpunit": "~12.2.6",
         "symfony/var-dumper": "~7.3.1",
         "vimeo/psalm": "~6.12.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "13411799f89d97bcee4d330ff33e2706",
+    "content-hash": "31a36584344c24848ba8ab4f3f50485b",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -5591,16 +5591,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.2.5",
+            "version": "12.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b71849b29f7a8d7574e4401873cb8b539896613f"
+                "reference": "638644c62a58f04974da115f98981c9b48564021"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b71849b29f7a8d7574e4401873cb8b539896613f",
-                "reference": "b71849b29f7a8d7574e4401873cb8b539896613f",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/638644c62a58f04974da115f98981c9b48564021",
+                "reference": "638644c62a58f04974da115f98981c9b48564021",
                 "shasum": ""
             },
             "require": {
@@ -5668,7 +5668,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.2.5"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.2.6"
             },
             "funding": [
                 {
@@ -5692,7 +5692,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T04:37:55+00:00"
+            "time": "2025-07-04T06:00:16+00:00"
         },
         {
             "name": "psr/http-factory",


### PR DESCRIPTION
Bumps `phpunit/phpunit` from `12.2.5` to `12.2.6`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`