### PR TITLE
Update phpunit/phpunit to version 13.0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^13.0.3",
+        "phpunit/phpunit": "^13.0.4",
         "symfony/var-dumper": "^8.0.4"
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88c18857786e47c8a4916836ac8dd7ea",
+    "content-hash": "7f3b5b744e69cb2ba1abd2bb93db3a7c",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -4132,16 +4132,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "13.0.3",
+            "version": "13.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a9c20642ffd2098c0f9e687c00849afbce2f23c7"
+                "reference": "915a2e7266f04c1867b2dc812abc86c34f1aa52f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a9c20642ffd2098c0f9e687c00849afbce2f23c7",
-                "reference": "a9c20642ffd2098c0f9e687c00849afbce2f23c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/915a2e7266f04c1867b2dc812abc86c34f1aa52f",
+                "reference": "915a2e7266f04c1867b2dc812abc86c34f1aa52f",
                 "shasum": ""
             },
             "require": {
@@ -4210,7 +4210,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.0.3"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.0.4"
             },
             "funding": [
                 {
@@ -4234,7 +4234,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-16T08:38:33+00:00"
+            "time": "2026-02-18T09:00:54+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Updates the `phpunit/phpunit` dependency from `13.0.3` to `13.0.4`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`