### PR TITLE
Update ghostwriter/event-dispatcher to version 6.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "composer-runtime-api": "~2.2.2",
         "composer/composer": "^2.9.5",
         "ghostwriter/container": "^6.0.1",
-        "ghostwriter/event-dispatcher": "^6.0.2",
+        "ghostwriter/event-dispatcher": "^6.1.0",
         "ghostwriter/filesystem": "0.2.0",
         "ghostwriter/json": "^3.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b00b7e6c675eaedb46a8e3cbabdaceb1",
+    "content-hash": "f54f6a9cd4e0ba88918e428a44570304",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -629,16 +629,16 @@
         },
         {
             "name": "ghostwriter/container",
-            "version": "6.0.1",
+            "version": "6.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/container.git",
-                "reference": "bcfb2a1e2cbff14df8d6f3fb9cc12a4c3bb369d4"
+                "reference": "478b61f4b95ea95969e6552f29d539c81fed10d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/container/zipball/bcfb2a1e2cbff14df8d6f3fb9cc12a4c3bb369d4",
-                "reference": "bcfb2a1e2cbff14df8d6f3fb9cc12a4c3bb369d4",
+                "url": "https://api.github.com/repos/ghostwriter/container/zipball/478b61f4b95ea95969e6552f29d539c81fed10d6",
+                "reference": "478b61f4b95ea95969e6552f29d539c81fed10d6",
                 "shasum": ""
             },
             "require": {
@@ -652,14 +652,20 @@
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^12.4.3",
-                "symfony/var-dumper": "^7.3.5"
+                "phpunit/phpunit": "^13.1.3",
+                "symfony/var-dumper": "^8.0.8"
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/ghostwriter/container",
+                    "name": "ghostwriter/container"
+                },
                 "ghostwriter": {
                     "container": {
-                        "definition": "Ghostwriter\\Container\\Service\\Definition\\ContainerDefinition"
+                        "provider": [
+                            "Ghostwriter\\Container\\Service\\Provider\\ContainerProvider"
+                        ]
                     }
                 }
             },
@@ -670,7 +676,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-4-Clause"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
@@ -698,24 +704,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-18T05:56:22+00:00"
+            "time": "2026-04-14T14:00:13+00:00"
         },
         {
             "name": "ghostwriter/event-dispatcher",
-            "version": "6.0.2",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/event-dispatcher.git",
-                "reference": "812d1be3c2850d9901a1e471dd2c0e20bbd15b2a"
+                "reference": "acdf7450096767814e716906dc453cfd0c24c1e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/event-dispatcher/zipball/812d1be3c2850d9901a1e471dd2c0e20bbd15b2a",
-                "reference": "812d1be3c2850d9901a1e471dd2c0e20bbd15b2a",
+                "url": "https://api.github.com/repos/ghostwriter/event-dispatcher/zipball/acdf7450096767814e716906dc453cfd0c24c1e8",
+                "reference": "acdf7450096767814e716906dc453cfd0c24c1e8",
                 "shasum": ""
             },
             "require": {
-                "ghostwriter/container": "^6.0.1",
+                "ghostwriter/container": "^6.1.1",
                 "php": "~8.4.0 || ~8.5.0",
                 "psr/event-dispatcher": "^1.0.0"
             },
@@ -726,14 +732,18 @@
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^12.4.4",
-                "symfony/var-dumper": "^7.3.5"
+                "phpunit/phpunit": "^13.1.3",
+                "symfony/var-dumper": "^8.0.8"
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/ghostwriter/event-dispatcher",
+                    "name": "ghostwriter/event-dispatcher"
+                },
                 "ghostwriter": {
                     "container": {
-                        "definition": "Ghostwriter\\EventDispatcher\\Container\\EventDispatcherDefinition"
+                        "provider": "Ghostwriter\\EventDispatcher\\Container\\EventDispatcherProvider"
                     }
                 }
             },
@@ -744,7 +754,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-4-Clause"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
@@ -775,7 +785,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-23T22:18:37+00:00"
+            "time": "2026-04-14T16:31:20+00:00"
         },
         {
             "name": "ghostwriter/filesystem",


### PR DESCRIPTION
Updates the `ghostwriter/event-dispatcher` dependency from `6.0.2` to `6.1.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`