### PR TITLE
Update phpunit/phpunit to version 13.1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^13.1.5",
+        "phpunit/phpunit": "^13.1.6",
         "symfony/var-dumper": "^8.0.8"
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1248c1f67e7b9eb08688b75c5d78200",
+    "content-hash": "fe86d2369219313c432d0993cf4eb9e8",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2691,12 +2691,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "33c77a2ba3223da098d93f71347784d2680e905d"
+                "reference": "16d0a0e7e8f8cb9a1a6ef7eeb7e6a1e36c8e90dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/33c77a2ba3223da098d93f71347784d2680e905d",
-                "reference": "33c77a2ba3223da098d93f71347784d2680e905d",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/16d0a0e7e8f8cb9a1a6ef7eeb7e6a1e36c8e90dd",
+                "reference": "16d0a0e7e8f8cb9a1a6ef7eeb7e6a1e36c8e90dd",
                 "shasum": ""
             },
             "require": {
@@ -2810,7 +2810,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-16T05:50:44+00:00"
+            "time": "2026-04-16T07:46:10+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -3566,16 +3566,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "13.1.5",
+            "version": "13.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "89adcba73441b38db31d5c0473b61e2907311db0"
+                "reference": "c3c414ea438e5a37d00697eaea43e6e05e201a42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/89adcba73441b38db31d5c0473b61e2907311db0",
-                "reference": "89adcba73441b38db31d5c0473b61e2907311db0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c3c414ea438e5a37d00697eaea43e6e05e201a42",
+                "reference": "c3c414ea438e5a37d00697eaea43e6e05e201a42",
                 "shasum": ""
             },
             "require": {
@@ -3645,7 +3645,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.5"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.6"
             },
             "funding": [
                 {
@@ -3653,7 +3653,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-04-16T04:58:40+00:00"
+            "time": "2026-04-17T12:52:50+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
Updates the `phpunit/phpunit` dependency from `13.1.5` to `13.1.6`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`