### PR TITLE
Update boundwize/structarmed to version 0.6.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.7",
+        "boundwize/structarmed": "^0.6.8",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "062fd5e94df2e2543eb8937cf6200476",
+    "content-hash": "a523c91d6d916890d9a53b6041dcef73",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2691,16 +2691,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.7",
+            "version": "0.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "6fe4bc42f1434a24c4d1dcefdc1116f14dec67b4"
+                "reference": "e37f44fc1f61c2c96837eafcec90ed88a3c2d84b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/6fe4bc42f1434a24c4d1dcefdc1116f14dec67b4",
-                "reference": "6fe4bc42f1434a24c4d1dcefdc1116f14dec67b4",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/e37f44fc1f61c2c96837eafcec90ed88a3c2d84b",
+                "reference": "e37f44fc1f61c2c96837eafcec90ed88a3c2d84b",
                 "shasum": ""
             },
             "require": {
@@ -2749,7 +2749,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.7"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.8"
             },
             "funding": [
                 {
@@ -2757,7 +2757,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-18T12:23:19+00:00"
+            "time": "2026-05-18T16:40:17+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.7` to `0.6.8`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`