### PR TITLE
Update phpunit/phpunit to version 13.1.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/testify": "^0.1.1",
         "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^13.1.11",
+        "phpunit/phpunit": "^13.1.12",
         "symfony/var-dumper": "^8.0.8"
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9fb349da3b0c1ed74a5d03210365d438",
+    "content-hash": "5e2a95b3b022729910d8e923ac67d077",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2919,16 +2919,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "afececade2eef113f1d76cefdf06d33ca660b86f"
+                "reference": "eefd6f57c2aecfe81fe28f1faf3891428da5e776"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/afececade2eef113f1d76cefdf06d33ca660b86f",
-                "reference": "afececade2eef113f1d76cefdf06d33ca660b86f",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/eefd6f57c2aecfe81fe28f1faf3891428da5e776",
+                "reference": "eefd6f57c2aecfe81fe28f1faf3891428da5e776",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.7.9",
+                "boundwize/structarmed": "^0.7.10",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -3039,7 +3039,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-25T11:40:02+00:00"
+            "time": "2026-05-25T15:06:57+00:00"
         },
         {
             "name": "ghostwriter/config",
@@ -4039,16 +4039,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "13.1.11",
+            "version": "13.1.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0f540976373361d1b4549adcb87913ce2116e904"
+                "reference": "ca98c9f757c0e1e0778ab8ff80c4fb84152facf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0f540976373361d1b4549adcb87913ce2116e904",
-                "reference": "0f540976373361d1b4549adcb87913ce2116e904",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ca98c9f757c0e1e0778ab8ff80c4fb84152facf8",
+                "reference": "ca98c9f757c0e1e0778ab8ff80c4fb84152facf8",
                 "shasum": ""
             },
             "require": {
@@ -4070,7 +4070,7 @@
                 "sebastian/cli-parser": "^5.0.0",
                 "sebastian/comparator": "^8.2.1",
                 "sebastian/diff": "^8.3.0",
-                "sebastian/environment": "^9.3.1",
+                "sebastian/environment": "^9.3.2",
                 "sebastian/exporter": "^8.1.0",
                 "sebastian/git-state": "^1.0",
                 "sebastian/global-state": "^9.0.0",
@@ -4118,7 +4118,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.11"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.12"
             },
             "funding": [
                 {
@@ -4126,7 +4126,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-05-21T12:38:47+00:00"
+            "time": "2026-05-25T15:37:19+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
Updates the `phpunit/phpunit` dependency from `13.1.11` to `13.1.12`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`