### PR TITLE
Update `boundwize/structarmed` to version `0.9.3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.9.2",
+        "boundwize/structarmed": "^0.9.3",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/phpunit-assertions": "^0.1.0",
         "ghostwriter/testify": "^0.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "668c22446883caad62a7bb53680ab933",
+    "content-hash": "9e4690cf506342dfa749f4590b1446e2",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2787,16 +2787,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.9.2",
+            "version": "0.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "593002a6c94bcbdc2ae3ea19d8bfcf5164186a32"
+                "reference": "9631b1f9d39b2b0007feb39bfcec54d896f514a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/593002a6c94bcbdc2ae3ea19d8bfcf5164186a32",
-                "reference": "593002a6c94bcbdc2ae3ea19d8bfcf5164186a32",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/9631b1f9d39b2b0007feb39bfcec54d896f514a5",
+                "reference": "9631b1f9d39b2b0007feb39bfcec54d896f514a5",
                 "shasum": ""
             },
             "require": {
@@ -2849,7 +2849,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.9.2"
+                "source": "https://github.com/boundwize/structarmed/tree/0.9.3"
             },
             "funding": [
                 {
@@ -2857,7 +2857,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-30T12:22:12+00:00"
+            "time": "2026-05-31T04:40:09+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.9.2` to `0.9.3`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`